### PR TITLE
Add major ruby milestones to travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.0
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
+  - 2.2.10
 before_script:
   - gem install bundler
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Something like Gemika wasn't necessary here.  I've added all supported minor ruby versions to `.travis.yml` which will run specs under all those versions.

Resolves #5 